### PR TITLE
TestBot does not open files to send photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.2.3
+`TestBot.send_photo` does not open files.
+
 ## v0.2.2
 Added build to dependencies, for CD action.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and photos.
 Install with pip
 
 ```
-pip install "git+https://github.com/Daniel-Ibarrola/TelegramBot#egg=telegrambot"
+pip install ciresbot
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciresbot"
-version = "0.2.2"
+version = "0.2.3"
 description = "Telegram bot"
 readme = "README.md"
 authors = [{ name = "Daniel Ibarrola", email = "daniel.ibarrola.sanchez@gmail.com" }]
@@ -30,7 +30,7 @@ Homepage = "https://github.com/Daniel-Ibarrola/TelegramBot.git"
 telegrambot = "telegrambot.__main__:main"
 
 [tool.bumpver]
-current_version = "0.2.2"
+current_version = "0.2.3"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"

--- a/src/telegrambot/bot.py
+++ b/src/telegrambot/bot.py
@@ -11,7 +11,7 @@ class FakeResponse:
             files: Optional[dict[str, Any]] = None,
             msg: str = ""
     ):
-        self.ok = True,
+        self.ok = True
         self.status_code = 200
         self.res_type = res_type
         self.files = files
@@ -131,3 +131,19 @@ class TestBot(AbstractBot):
         res = FakeResponse(args[0], msg=msg)
         self.responses.append(res)
         return res
+
+    def send_photo(
+            self,
+            photo_path: str,
+            chat_id: str,
+            caption: str = "") -> tuple[bool, int, str]:
+        url = f"{self._base_url}sendPhoto?chat_id={chat_id}"
+        if caption:
+            url += f"&caption={caption}"
+
+        res = self._post_request(url, {"photo": photo_path})
+
+        if res is None:
+            return False, 500, ""
+
+        return res.ok, res.status_code, photo_path


### PR DESCRIPTION
`TestBot` can use the `send_photo` method without opening any real files, making it suitable for unit tests.